### PR TITLE
make naming consistent

### DIFF
--- a/back-in-out.glsl
+++ b/back-in-out.glsl
@@ -2,7 +2,7 @@
 #define PI 3.141592653589793
 #endif
 
-float backOut(float t) {
+float backInOut(float t) {
   float f = t < 0.5
     ? 2.0 * t
     : 1.0 - (2.0 * t - 1.0);
@@ -14,4 +14,4 @@ float backOut(float t) {
     : 0.5 * (1.0 - g) + 0.5;
 }
 
-#pragma glslify: export(backOut)
+#pragma glslify: export(backInOut)


### PR DESCRIPTION
`backOut` --> `backInOut` for consistency and avoiding issues when using both the `backOut` and `backInOut` function in a shader.
