### PR TITLE
Fix pow(x,y) undefined when x<0

### DIFF
--- a/cubic-in-out.glsl
+++ b/cubic-in-out.glsl
@@ -1,7 +1,7 @@
 float cubicInOut(float t) {
   return t < 0.5
     ? 4.0 * t * t * t
-    : 0.5 * pow(2.0 * t - 2.0, 3.0) + 1.0;
+    : 0.5 * -pow(2.0 - 2.0 * t, 3.0) + 1.0;
 }
 
 #pragma glslify: export(cubicInOut)

--- a/quartic-in-out.glsl
+++ b/quartic-in-out.glsl
@@ -1,7 +1,7 @@
 float quarticInOut(float t) {
   return t < 0.5
     ? +8.0 * pow(t, 4.0)
-    : -8.0 * pow(t - 1.0, 4.0) + 1.0;
+    : -8.0 * pow(1.0 - t, 4.0) + 1.0;
 }
 
 #pragma glslify: export(quarticInOut)

--- a/quartic-out.glsl
+++ b/quartic-out.glsl
@@ -1,5 +1,5 @@
 float quarticOut(float t) {
-  return pow(t - 1.0, 3.0) * (1.0 - t) + 1.0;
+  return pow(1.0 - t, 3.0) * (t - 1.0) + 1.0;
 }
 
 #pragma glslify: export(quarticOut)

--- a/quintic-in-out.glsl
+++ b/quintic-in-out.glsl
@@ -1,7 +1,7 @@
 float qinticInOut(float t) {
   return t < 0.5
     ? +16.0 * pow(t, 5.0)
-    : -0.5 * pow(2.0 * t - 2.0, 5.0) + 1.0;
+    : -0.5 * pow(2.0 - 2.0 * t, 5.0) + 1.0;
 }
 
 #pragma glslify: export(qinticInOut)

--- a/quintic-out.glsl
+++ b/quintic-out.glsl
@@ -1,5 +1,5 @@
 float qinticOut(float t) {
-  return 1.0 - (pow(t - 1.0, 5.0));
+  return 1.0 - pow(1.0 - t, 5.0);
 }
 
 #pragma glslify: export(qinticOut)

--- a/test/visual/.gitignore
+++ b/test/visual/.gitignore
@@ -1,3 +1,4 @@
 *.glsl
 !_base.glsl
 !frag.glsl
+!blue.glsl

--- a/test/visual/blue.glsl
+++ b/test/visual/blue.glsl
@@ -1,0 +1,5 @@
+precision mediump float;
+
+void main() {
+  gl_FragColor = vec4(0.2, 0.6, 0.9, 1.0);
+}


### PR DESCRIPTION
I used `quartic-out` in a project and when testing on some older hardware (ATI Radeon HD 2600 Pro 256MB, in a 2008 iMac), I found that it gave crazy results:

![quartic-out](https://user-images.githubusercontent.com/1940215/32777491-68322c1a-c98a-11e7-92e1-376c0b549021.png)

I narrowed it down to the pow() call, then found that actually `pow(x,y)` [is undefined when x<0](http://docs.gl/el3/pow). This pull request just tweaks the shaders so they avoid passing `x<0` to `pow`, which fixes all eases on this hardware:

![all eases after 9523fc4](https://user-images.githubusercontent.com/1940215/32777730-6a26154e-c98b-11e7-987f-7f8877839911.png)

 I also added a `blue.glsl` to get the tests working.